### PR TITLE
Security fix OOB read due to invalid count in stack/avrc/avrc_pars_ct

### DIFF
--- a/stack/avrc/avrc_pars_ct.cc
+++ b/stack/avrc/avrc_pars_ct.cc
@@ -581,6 +581,10 @@ static tAVRC_STS avrc_ctrl_pars_vendor_rsp(tAVRC_MSG_VENDOR* p_msg,
                        p_result->get_caps.capability_id,
                        p_result->get_caps.count);
       if (p_result->get_caps.capability_id == AVRC_CAP_COMPANY_ID) {
+        if (p_result->get_caps.count > AVRC_CAP_MAX_NUM_COMP_ID) {
+          android_errorWriteLog(0x534e4554, "205837191");
+          return AVRC_STS_INTERNAL_ERR;
+        }
         min_len += MIN(p_result->get_caps.count, AVRC_CAP_MAX_NUM_COMP_ID) * 3;
         if (len < min_len) goto length_error;
         for (int xx = 0; ((xx < p_result->get_caps.count) &&
@@ -590,6 +594,10 @@ static tAVRC_STS avrc_ctrl_pars_vendor_rsp(tAVRC_MSG_VENDOR* p_msg,
         }
       } else if (p_result->get_caps.capability_id ==
                  AVRC_CAP_EVENTS_SUPPORTED) {
+        if (p_result->get_caps.count > AVRC_CAP_MAX_NUM_EVT_ID) {
+          android_errorWriteLog(0x534e4554, "205837191");
+          return AVRC_STS_INTERNAL_ERR;
+        }
         min_len += MIN(p_result->get_caps.count, AVRC_CAP_MAX_NUM_EVT_ID);
         if (len < min_len) goto length_error;
         for (int xx = 0; ((xx < p_result->get_caps.count) &&


### PR DESCRIPTION
Bug: 205837191
Tag: #security
Test: PoC test program
Ignore-AOSP-First: Security
Change-Id: I7b5bcb6551a8c0c015566327e13ba719271ce374
Merged-In: I7b5bcb6551a8c0c015566327e13ba719271ce374
(cherry picked from commit 697942b47f92b173e1cd87bb404e2386db958630)
Merged-In:I7b5bcb6551a8c0c015566327e13ba719271ce374